### PR TITLE
[feat]: 커뮤니티 글 상태 변경 API 기능 구현

### DIFF
--- a/src/main/java/com/umc/refit/domain/entity/Posts.java
+++ b/src/main/java/com/umc/refit/domain/entity/Posts.java
@@ -55,4 +55,8 @@ public class Posts {
         this.detail = postDto.getDetail();
         this.postState = postDto.getPostState();
     }
+
+    public void changeState(Integer newState){
+        this.postState = newState;
+    }
 }

--- a/src/main/java/com/umc/refit/web/controller/CommunityController.java
+++ b/src/main/java/com/umc/refit/web/controller/CommunityController.java
@@ -138,6 +138,19 @@ public class CommunityController {
         communityService.deletePost(postId, authentication);
     }
 
+    /*게시글 상태 변경 API*/
+    @PatchMapping("/{postId}")
+    public void changeState(
+            @PathVariable Long postId, Authentication authentication, HttpServletRequest request){
+
+        if (authentication == null) {
+            ExceptionType exception = (ExceptionType) request.getAttribute("exception");
+            throw new TokenException(exception, exception.getCode(), exception.getErrorMessage());
+        }
+
+        communityService.changeState(postId, authentication);
+    }
+
 
     /*게시글 스크랩 API*/
     @PostMapping("/{postId}/scrap")

--- a/src/main/java/com/umc/refit/web/service/CommunityService.java
+++ b/src/main/java/com/umc/refit/web/service/CommunityService.java
@@ -212,4 +212,39 @@ public class CommunityService {
             throw new IllegalStateException("삭제 권한이 없습니다.");
         }
     }
+
+    /*게시글 상태 변경*/
+    public void changeState(Long postId, Authentication authentication) {
+        //로그인 유저
+        String userId = authentication.getName();
+        Member member = memberService.findMemberByLoginId(userId)
+                .orElseThrow(() -> new NoSuchElementException("No member found with this user id"));
+
+        Posts findPost = findPostById(postId)
+                .orElseThrow(() -> new NoSuchElementException("No post found with this post id"));
+
+        if(!member.getId().equals(findPost.getMember().getId())){
+            throw new IllegalStateException("이 게시글 상태 변경 권한이 없습니다.");
+        }
+
+        //나눔중 -> 나눔완료
+        if(findPost.getPostState().equals(0)){
+            findPost.changeState(2);
+            return;
+        }
+        if(findPost.getPostState().equals(2)){
+            findPost.changeState(0);
+            return;
+        }
+
+        //판매중 -> 판매완료
+        if(findPost.getPostState().equals(1)){
+            findPost.changeState(3);
+            return;
+        }
+        if(findPost.getPostState().equals(3)){
+            findPost.changeState(1);
+            return;
+        }
+    }
 }


### PR DESCRIPTION
1. 자신의 글 상태 변경 가능
2. 나눔 중이면 나눔 완료, 나눔 완료면 나눔 중으로 글 상태 변경
3. 판매 중이면 판매 완료, 판매 완료면 판매 중으로 글 상태 변경