### PR TITLE
[feat]: 채팅 거래 완료 API 기능 구현

### DIFF
--- a/src/main/java/com/umc/refit/domain/dto/chat/TradeRequestDto.java
+++ b/src/main/java/com/umc/refit/domain/dto/chat/TradeRequestDto.java
@@ -1,0 +1,11 @@
+package com.umc.refit.domain.dto.chat;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TradeRequestDto {
+    private Long postId;
+    private String username;
+}

--- a/src/main/java/com/umc/refit/domain/entity/Posts.java
+++ b/src/main/java/com/umc/refit/domain/entity/Posts.java
@@ -80,4 +80,7 @@ public class Posts extends BaseTimeEntity {
     public void removeBuyer(){
         this.buyer = null;
     }
+    public void initializeBuyer(Member member){
+        this.buyer = member;
+    }
 }

--- a/src/main/java/com/umc/refit/web/controller/TradeController.java
+++ b/src/main/java/com/umc/refit/web/controller/TradeController.java
@@ -1,0 +1,34 @@
+package com.umc.refit.web.controller;
+
+
+import com.umc.refit.domain.dto.chat.TradeRequestDto;
+import com.umc.refit.exception.ExceptionType;
+import com.umc.refit.exception.member.TokenException;
+import com.umc.refit.web.service.CommunityService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/trade")
+@RequiredArgsConstructor
+public class TradeController {
+
+    private final CommunityService communityService;
+
+    /*거래 완료 API*/
+    @PostMapping
+    public void tradeComplete(
+            @RequestBody TradeRequestDto tradeRequestDto,
+            Authentication authentication, HttpServletRequest request){
+
+        if (authentication == null) {
+            ExceptionType exception = (ExceptionType) request.getAttribute("exception");
+            throw new TokenException(exception, exception.getCode(), exception.getErrorMessage());
+        }
+
+        communityService.trade(tradeRequestDto, authentication);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,9 +8,9 @@ spring:
       enabled: ALWAYS
 
   datasource:
-    url: jdbc:mysql://localhost:${DATABASE_PORT}/${DATABASE_NAME}
-    username: ${DATABASE_USER}
-    password: ${DATABASE_PASSWORD}
+    url: jdbc:mysql://localhost:3306/refit
+    username: root
+    password: root
     driver-class-name: com.mysql.cj.jdbc.Driver
 
 
@@ -57,8 +57,8 @@ cloud:
     s3:
       bucket: refit-bucket
     credentials:
-      access-key: ${S3_KEY}
-      secret-key: Rx4PxP50wf4P9JHj1MNDAqZw8SZ8+8Z8zQhdZHm4
+      access-key:
+      secret-key: 
 
 
 logging:


### PR DESCRIPTION
- 나눔 중 글:
1. 글 상태를 나눔완료로 변경
2. "Posts 객체의 'buyer' 멤버 변수에 채팅 대상자의 정보를 저장

- 판매 중 글:
1. 글 상태를 판매완료로 변경
2. "Posts 객체의 'buyer' 멤버 변수에 채팅 대상자의 정보를 저장
