### PR TITLE
[feat] : 마이 패이지 내 정보 조회 API

### DIFF
--- a/src/main/java/com/umc/refit/domain/dto/mypage/GetMyInfoResponseDto.java
+++ b/src/main/java/com/umc/refit/domain/dto/mypage/GetMyInfoResponseDto.java
@@ -1,0 +1,30 @@
+package com.umc.refit.domain.dto.mypage;
+
+import com.umc.refit.domain.entity.Member;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetMyInfoResponseDto {
+    private String imageUrl;
+    private String email;
+    private String loginId;
+    private String name;
+    private String birth;
+    private Integer gender;
+
+    public static GetMyInfoResponseDto from(Member member) {
+        return GetMyInfoResponseDto.builder()
+                .imageUrl(member.getImageUrl())
+                .email(member.getEmail())
+                .loginId(member.getLoginId())
+                .name(member.getName())
+                .birth(member.getBirth())
+                .gender(member.getGender())
+                .build();
+
+    }
+}

--- a/src/main/java/com/umc/refit/domain/entity/Member.java
+++ b/src/main/java/com/umc/refit/domain/entity/Member.java
@@ -14,10 +14,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Entity
-@Getter @Setter
+@Getter
+@Setter
 public class Member implements UserDetails {
 
-    @Id @GeneratedValue
+    @Id
+    @GeneratedValue
     @Column(name = "member_id")
     private Long id;
     private String loginId;
@@ -27,6 +29,9 @@ public class Member implements UserDetails {
     private String birth;
     private String socialType;
     private Integer gender;
+    private String imageUrl;
+    @ElementCollection(fetch = FetchType.EAGER)
+    private List<String> roles = new ArrayList<>();
 
     public Member(String name) {
         this.name = name;
@@ -53,9 +58,6 @@ public class Member implements UserDetails {
     public Member() {
 
     }
-
-    @ElementCollection(fetch = FetchType.EAGER)
-    private List<String> roles = new ArrayList<>();
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/umc/refit/web/controller/MypageController.java
+++ b/src/main/java/com/umc/refit/web/controller/MypageController.java
@@ -1,11 +1,15 @@
 package com.umc.refit.web.controller;
 
 import com.umc.refit.domain.dto.community.PostMainResponseDto;
+import com.umc.refit.domain.dto.mypage.GetMyInfoResponseDto;
 import com.umc.refit.exception.ExceptionType;
 import com.umc.refit.exception.member.TokenException;
 import com.umc.refit.web.service.CommunityService;
+import com.umc.refit.web.service.MyPageService;
 import com.umc.refit.web.service.ScrapService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,25 +19,30 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 @RestController
-@RequestMapping("/mypage")
+@RequestMapping("/refit/mypage")
 @RequiredArgsConstructor
 public class MypageController {
 
     private final CommunityService communityService;
     private final ScrapService scrapService;
+    private final MyPageService myPageService;
 
     Integer give = 0;
     Integer sell = 1;
 
-    /*내 피드 - 나눔 API*/
-    @GetMapping("/myfeed/give")
-    public List<PostMainResponseDto> myFeedGvie(
-            Authentication authentication, HttpServletRequest request){
-
+    private static void checkAuthentication(Authentication authentication, HttpServletRequest request) {
         if (authentication == null) {
             ExceptionType exception = (ExceptionType) request.getAttribute("exception");
             throw new TokenException(exception, exception.getCode(), exception.getErrorMessage());
         }
+    }
+
+    /*내 피드 - 나눔 API*/
+    @GetMapping("/myfeed/give")
+    public List<PostMainResponseDto> myFeedGvie(
+            Authentication authentication, HttpServletRequest request) {
+
+        checkAuthentication(authentication, request);
 
         List<PostMainResponseDto> postList = communityService.myFeedPosts(give, authentication);
 
@@ -43,12 +52,9 @@ public class MypageController {
     /*내 피드 - 판매 API*/
     @GetMapping("/myfeed/sell")
     public List<PostMainResponseDto> myFeedSell(
-            Authentication authentication, HttpServletRequest request){
+            Authentication authentication, HttpServletRequest request) {
 
-        if (authentication == null) {
-            ExceptionType exception = (ExceptionType) request.getAttribute("exception");
-            throw new TokenException(exception, exception.getCode(), exception.getErrorMessage());
-        }
+        checkAuthentication(authentication, request);
 
         List<PostMainResponseDto> postList = communityService.myFeedPosts(sell, authentication);
 
@@ -58,28 +64,21 @@ public class MypageController {
     /*내 피드 - 구매 API*/
     @GetMapping("/myfeed/buy")
     public List<PostMainResponseDto> myFeedBuy(
-            Authentication authentication, HttpServletRequest request){
+            Authentication authentication, HttpServletRequest request) {
 
-        if (authentication == null) {
-            ExceptionType exception = (ExceptionType) request.getAttribute("exception");
-            throw new TokenException(exception, exception.getCode(), exception.getErrorMessage());
-        }
+        checkAuthentication(authentication, request);
 
         List<PostMainResponseDto> postList = communityService.myFeedBuy(authentication);
 
         return postList;
     }
 
-
     /*스크랩 - 나눔 API*/
     @GetMapping("/scrap/give")
     public List<PostMainResponseDto> myScrapGive(
-            Authentication authentication, HttpServletRequest request){
+            Authentication authentication, HttpServletRequest request) {
 
-        if (authentication == null) {
-            ExceptionType exception = (ExceptionType) request.getAttribute("exception");
-            throw new TokenException(exception, exception.getCode(), exception.getErrorMessage());
-        }
+        checkAuthentication(authentication, request);
 
         List<PostMainResponseDto> postList = scrapService.findMyScraps(give, authentication);
 
@@ -89,15 +88,21 @@ public class MypageController {
     /*스크랩 - 판매 API*/
     @GetMapping("/scrap/sell")
     public List<PostMainResponseDto> myScrapSell(
-            Authentication authentication, HttpServletRequest request){
+            Authentication authentication, HttpServletRequest request) {
 
-        if (authentication == null) {
-            ExceptionType exception = (ExceptionType) request.getAttribute("exception");
-            throw new TokenException(exception, exception.getCode(), exception.getErrorMessage());
-        }
+        checkAuthentication(authentication, request);
 
         List<PostMainResponseDto> postList = scrapService.findMyScraps(sell, authentication);
 
         return postList;
+    }
+
+    /* 내 정보 조회 API */
+    @GetMapping("/info")
+    public ResponseEntity<GetMyInfoResponseDto> getMyInfo(
+            Authentication authentication, HttpServletRequest request
+    ) {
+        checkAuthentication(authentication, request);
+        return new ResponseEntity<>(this.myPageService.getMyInfo(authentication), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/umc/refit/web/service/MyPageService.java
+++ b/src/main/java/com/umc/refit/web/service/MyPageService.java
@@ -1,0 +1,23 @@
+package com.umc.refit.web.service;
+
+import com.umc.refit.domain.dto.mypage.GetMyInfoResponseDto;
+import com.umc.refit.web.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MyPageService {
+
+    private final MemberRepository memberRepository;
+
+    public GetMyInfoResponseDto getMyInfo(Authentication authentication) {
+        return GetMyInfoResponseDto.from(this.memberRepository.findByLoginId(
+                        authentication.getName())
+                .orElseThrow(() -> new UsernameNotFoundException("No member found with this user id")));
+    }
+}


### PR DESCRIPTION
- PR 제목 : 마이 페이지 내 정보 조회 API 구현
- PR 날짜 : 2023/08/01
- PR 내용 : 일반적인 `Member` 테이블에는 별도의 Imageurl 이 존재하지 않았습니다. 하지만 내 정보에는 ImageUrl 이 존재합니다. 
이때문에  `MyInfo(나의정보)` 를 별도로 만들어야 하나 고민했는데 단 하나의 필드 때문에 별도의 테이블을 만드는 건 데이터베이스 자원 낭비라고 생각했으며 `Member` 테이블에 ImageUrl 을 추가하여 만약 내 정보를 수정하지 않았으면 null 로 수정하여 imageUrl 을 추가하면 해당 `Member` 테이블에 ImageUrl 을 업데이트 하는 식으로 구현하려고 합니다.