### PR TITLE
[feat] : 마이 페이지 회원 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/umc/refit/domain/dto/mypage/UpdateMyInfoRequestDto.java
+++ b/src/main/java/com/umc/refit/domain/dto/mypage/UpdateMyInfoRequestDto.java
@@ -1,0 +1,17 @@
+package com.umc.refit.domain.dto.mypage;
+
+import lombok.*;
+
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateMyInfoRequestDto {
+    @Size(min = 1, max = 255)
+    private String name;
+    private String birth;
+    private Integer gender;
+}

--- a/src/main/java/com/umc/refit/domain/entity/Member.java
+++ b/src/main/java/com/umc/refit/domain/entity/Member.java
@@ -1,6 +1,7 @@
 package com.umc.refit.domain.entity;
 
 import com.umc.refit.domain.dto.member.JoinDto;
+import com.umc.refit.domain.dto.mypage.UpdateMyInfoRequestDto;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
@@ -89,5 +90,12 @@ public class Member implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    public void updateMemberByMyInfo(UpdateMyInfoRequestDto request, String requestedImageUrl) {
+        name = request.getName();
+        birth = request.getBirth();
+        gender = request.getGender();
+        imageUrl = requestedImageUrl;
     }
 }

--- a/src/main/java/com/umc/refit/web/controller/MypageController.java
+++ b/src/main/java/com/umc/refit/web/controller/MypageController.java
@@ -2,6 +2,7 @@ package com.umc.refit.web.controller;
 
 import com.umc.refit.domain.dto.community.PostMainResponseDto;
 import com.umc.refit.domain.dto.mypage.GetMyInfoResponseDto;
+import com.umc.refit.domain.dto.mypage.UpdateMyInfoRequestDto;
 import com.umc.refit.exception.ExceptionType;
 import com.umc.refit.exception.member.TokenException;
 import com.umc.refit.web.service.CommunityService;
@@ -11,12 +12,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 import java.util.List;
 
 @RestController
@@ -105,6 +105,23 @@ public class MypageController {
     ) {
         checkAuthentication(authentication, request);
         return new ResponseEntity<>(this.myPageService.getMyInfo(authentication), HttpStatus.OK);
+    }
+
+
+    /* 내 정보 수정 API */
+    @PatchMapping("/info")
+    public ResponseEntity<Void> updateMyInfo(
+            @RequestPart(value = "image", required = false) MultipartFile multipartFile,
+            @Valid @RequestPart UpdateMyInfoRequestDto request,
+            Authentication authentication,
+            HttpServletRequest httpServletRequest
+    ) {
+        if (authentication == null) {
+            ExceptionType exception = (ExceptionType) httpServletRequest.getAttribute("exception");
+            throw new TokenException(exception, exception.getCode(), exception.getErrorMessage());
+        }
+        this.myPageService.updateMyInfo(multipartFile, request, authentication);
+        return ResponseEntity.ok().build();
     }
 
     /* 이름(닉네임) 중복 확인 API */

--- a/src/main/java/com/umc/refit/web/service/MyPageService.java
+++ b/src/main/java/com/umc/refit/web/service/MyPageService.java
@@ -1,13 +1,20 @@
 package com.umc.refit.web.service;
 
 import com.umc.refit.domain.dto.mypage.GetMyInfoResponseDto;
+import com.umc.refit.domain.dto.mypage.UpdateMyInfoRequestDto;
+import com.umc.refit.domain.dto.s3.ImageDto;
 import com.umc.refit.web.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Objects;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -15,6 +22,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class MyPageService {
 
     private final MemberRepository memberRepository;
+
+    private final S3UploadService s3UploadService;
+
+    private final String bucketDirName = "myInfo";
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
 
     @Transactional(readOnly = true)
     public GetMyInfoResponseDto getMyInfo(Authentication authentication) {
@@ -26,5 +40,28 @@ public class MyPageService {
     @Transactional(readOnly = true)
     public Boolean checkInsertedName(String name) {
         return this.memberRepository.findByName(name).isPresent();
+    }
+
+
+    @Transactional
+    public void updateMyInfo(MultipartFile multipartFile, UpdateMyInfoRequestDto request, Authentication authentication) {
+
+        if (null == multipartFile) {
+            this.memberRepository.findByLoginId(authentication.getName())
+                    .orElseThrow(() -> new UsernameNotFoundException("No member found with this user id"))
+                    .updateMemberByMyInfo(request, null);
+            return;
+        }
+
+        ImageDto imageDto;
+        try {
+            imageDto = this.s3UploadService.uploadFile(Objects.requireNonNull(multipartFile), bucketName, bucketDirName);
+            this.memberRepository.findByLoginId(authentication.getName())
+                    .orElseThrow(() -> new UsernameNotFoundException("No member found with this user id"))
+                    .updateMemberByMyInfo(request, imageDto.getImageUrl());
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
- PR 제목 : 마이 페이지 회원 정보 수정 API 
- PR 날짜 : 2023/08/02
- PR 내용 : 
    1. 회원 정보 수정은 image 가 없는 경우와 있는 경우로 나뉩니다.
    2. 위와 같은 이유로 두가지 Case 로 나누어 로직을 구성했으며 image 가 없는 경우 기존 member 의 `imageUrl` 필드를 null 로 변경합니다.
    3. 이로써 `사진 삭제 API` 까지 한번에 구현 가능합니다. -> 서버는 프론트에서 보내는 최종본만 받아서 처리하면됩니다.